### PR TITLE
Add different customization options

### DIFF
--- a/IQActionSheetPickerView/IQActionSheetPickerView.h
+++ b/IQActionSheetPickerView/IQActionSheetPickerView.h
@@ -91,6 +91,10 @@ typedef NS_ENUM(NSUInteger, IQActionSheetPickerStyle) {
  Color for buttons
  */
 @property(nonatomic, strong) UIColor *toolbarButtonColor UI_APPEARANCE_SELECTOR;
+/*!
+ Background color for the `UIPickerView`
+ */
+@property(nonatomic, strong) UIColor *pickerViewBackgroundColor UI_APPEARANCE_SELECTOR;
 
 
 ///----------------------

--- a/IQActionSheetPickerView/IQActionSheetPickerView.h
+++ b/IQActionSheetPickerView/IQActionSheetPickerView.h
@@ -48,10 +48,11 @@ typedef NS_ENUM(NSUInteger, IQActionSheetPickerStyle) {
     IQActionSheetPickerStyleTimePicker,
 };
 
-/// Identifies an attributed string of the toolbar title for normal state.
-extern NSString * const kAttributesForNormalStateKey;
-/// Identifies an attributed string of the toolbar title for highlighted state.
-extern NSString * const kAttributesForHighlightedStateKey;
+/// These keys are used to set text attributes for both `Cancel` and `Done` toolbar buttons.
+/// Identifies an attributed string of the toolbar button title for normal state.
+extern NSString * const kIQActionSheetAttributesForNormalStateKey;
+/// Identifies an attributed string of the toolbar button title for highlighted state.
+extern NSString * const kIQActionSheetAttributesForHighlightedStateKey;
 
 @class IQActionSheetPickerView;
 

--- a/IQActionSheetPickerView/IQActionSheetPickerView.h
+++ b/IQActionSheetPickerView/IQActionSheetPickerView.h
@@ -161,12 +161,20 @@ extern NSString * const kAttributesForHighlightedStateKey;
 @property(nonatomic, strong) NSArray *widthsForComponents;
 
 /*!
- Font for the UIPickerView
+ Font for the UIPickerView components
+ */
+@property(nonatomic, strong) UIFont *pickerComponentsFont UI_APPEARANCE_SELECTOR;
+/*!
+ *  Color for the UIPickerView
+ */
+@property(nonatomic, strong) UIColor *pickerComponentsColor UI_APPEARANCE_SELECTOR;
+/*!
+ Font for the UIToolBar title
  */
 @property(nonatomic, strong) UIFont *titleFont UI_APPEARANCE_SELECTOR;
 
 /*!
- *  Color for the UIPickerView
+ *  Color for the UIToolBar title
  */
 @property(nonatomic, strong) UIColor *titleColor UI_APPEARANCE_SELECTOR;
 

--- a/IQActionSheetPickerView/IQActionSheetPickerView.h
+++ b/IQActionSheetPickerView/IQActionSheetPickerView.h
@@ -48,6 +48,11 @@ typedef NS_ENUM(NSUInteger, IQActionSheetPickerStyle) {
     IQActionSheetPickerStyleTimePicker,
 };
 
+/// Identifies an attributed string of the toolbar title for normal state.
+extern NSString * const kAttributesForNormalStateKey;
+/// Identifies an attributed string of the toolbar title for highlighted state.
+extern NSString * const kAttributesForHighlightedStateKey;
+
 @class IQActionSheetPickerView;
 
 /*!
@@ -95,7 +100,14 @@ typedef NS_ENUM(NSUInteger, IQActionSheetPickerStyle) {
  Background color for the `UIPickerView`
  */
 @property(nonatomic, strong) UIColor *pickerViewBackgroundColor UI_APPEARANCE_SELECTOR;
-
+/*!
+ A dictionary containing the attributed strings of the cancel button for normal and highlighted states.
+ */
+@property(nonatomic, strong) NSDictionary *cancelButtonAttributes UI_APPEARANCE_SELECTOR;
+/*!
+ A dictionary containing the attributed strings of the done button for normal and highlighted states.
+ */
+@property(nonatomic, strong) NSDictionary *doneButtonAttributes UI_APPEARANCE_SELECTOR;
 
 ///----------------------
 /// @name Show / Hide

--- a/IQActionSheetPickerView/IQActionSheetPickerView.h
+++ b/IQActionSheetPickerView/IQActionSheetPickerView.h
@@ -97,10 +97,6 @@ extern NSString * const kAttributesForHighlightedStateKey;
  */
 @property(nonatomic, strong) UIColor *toolbarButtonColor UI_APPEARANCE_SELECTOR;
 /*!
- Background color for the `UIPickerView`
- */
-@property(nonatomic, strong) UIColor *pickerViewBackgroundColor UI_APPEARANCE_SELECTOR;
-/*!
  A dictionary containing the attributed strings of the cancel button for normal and highlighted states.
  */
 @property(nonatomic, strong) NSDictionary *cancelButtonAttributes UI_APPEARANCE_SELECTOR;
@@ -164,6 +160,10 @@ extern NSString * const kAttributesForHighlightedStateKey;
  Font for the UIPickerView components
  */
 @property(nonatomic, strong) UIFont *pickerComponentsFont UI_APPEARANCE_SELECTOR;
+/*!
+ Background color for the `UIPickerView`
+ */
+@property(nonatomic, strong) UIColor *pickerViewBackgroundColor UI_APPEARANCE_SELECTOR;
 /*!
  *  Color for the UIPickerView
  */

--- a/IQActionSheetPickerView/IQActionSheetPickerView.m
+++ b/IQActionSheetPickerView/IQActionSheetPickerView.m
@@ -26,9 +26,9 @@
 #import <QuartzCore/QuartzCore.h>
 #import "IQActionSheetViewController.h"
 
-NSString * const kAttributesForNormalStateKey = @"kAttributesForNormalStateKey";
+NSString * const kIQActionSheetAttributesForNormalStateKey = @"kIQActionSheetAttributesForNormalStateKey";
 /// Identifies an attributed string of the toolbar title for highlighted state.
-NSString * const kAttributesForHighlightedStateKey = @"kAttributesForHighlightedStateKey";
+NSString * const kIQActionSheetAttributesForHighlightedStateKey = @"kIQActionSheetAttributesForHighlightedStateKey";
 
 @interface IQActionSheetPickerView ()<UIPickerViewDataSource,UIPickerViewDelegate>
 {
@@ -195,12 +195,12 @@ NSString * const kAttributesForHighlightedStateKey = @"kAttributesForHighlighted
  *  @param cancelButtonAttributes Cancel Button Title Attributes
  */
 -(void)setCancelButtonAttributes:(NSDictionary *)cancelButtonAttributes{
-  id attributesForCancelButtonNormalState = [cancelButtonAttributes objectForKey:kAttributesForNormalStateKey];
+  id attributesForCancelButtonNormalState = [cancelButtonAttributes objectForKey:kIQActionSheetAttributesForNormalStateKey];
   if (attributesForCancelButtonNormalState != nil && [attributesForCancelButtonNormalState isKindOfClass:[NSDictionary class]]) {
     [_cancelButton setTitleTextAttributes:(NSDictionary *)attributesForCancelButtonNormalState forState:UIControlStateNormal];
   }
   
-  id attributesForCancelButtonnHighlightedState = [cancelButtonAttributes objectForKey:  kAttributesForHighlightedStateKey];
+  id attributesForCancelButtonnHighlightedState = [cancelButtonAttributes objectForKey:  kIQActionSheetAttributesForHighlightedStateKey];
   if (attributesForCancelButtonnHighlightedState != nil && [attributesForCancelButtonnHighlightedState isKindOfClass:[NSDictionary class]]) {
     [_cancelButton setTitleTextAttributes:(NSDictionary *)attributesForCancelButtonnHighlightedState forState:UIControlStateHighlighted];
   }
@@ -212,13 +212,13 @@ NSString * const kAttributesForHighlightedStateKey = @"kAttributesForHighlighted
  *  @param cancelButtonAttributes Done Button Title Attributes
  */
 -(void)setDoneButtonAttributes:(NSDictionary *)doneButtonAttributes{
-  id attributesForDoneButtonNormalState = [doneButtonAttributes objectForKey:kAttributesForNormalStateKey];
+  id attributesForDoneButtonNormalState = [doneButtonAttributes objectForKey:kIQActionSheetAttributesForNormalStateKey];
   if (attributesForDoneButtonNormalState != nil && [attributesForDoneButtonNormalState isKindOfClass:[NSDictionary class]]) {
     [_doneButton setTitleTextAttributes:(NSDictionary *)attributesForDoneButtonNormalState forState:UIControlStateNormal];
   }
   
   
-  id attributesForDoneButtonnHighlightedState = [doneButtonAttributes objectForKey:  kAttributesForHighlightedStateKey];
+  id attributesForDoneButtonnHighlightedState = [doneButtonAttributes objectForKey:  kIQActionSheetAttributesForHighlightedStateKey];
   if (attributesForDoneButtonnHighlightedState != nil && [attributesForDoneButtonnHighlightedState isKindOfClass:[NSDictionary class]]) {
     [_doneButton setTitleTextAttributes:(NSDictionary *)attributesForDoneButtonnHighlightedState forState:UIControlStateHighlighted];
   }

--- a/IQActionSheetPickerView/IQActionSheetPickerView.m
+++ b/IQActionSheetPickerView/IQActionSheetPickerView.m
@@ -36,7 +36,9 @@ NSString * const kAttributesForHighlightedStateKey = @"kAttributesForHighlighted
     UIDatePicker    *_datePicker;
     UIToolbar       *_actionToolbar;
     UILabel         *_titleLabel;
-
+    UIBarButtonItem *_cancelButton;
+    UIBarButtonItem *_doneButton;
+  
     IQActionSheetViewController *_actionSheetController;
 }
 
@@ -75,20 +77,9 @@ NSString * const kAttributesForHighlightedStateKey = @"kAttributesForHighlighted
             NSMutableArray *items = [[NSMutableArray alloc] init];
             
             //  Create a cancel button to show on keyboard to resign it. Adding a selector to resign it.
-            UIBarButtonItem *cancelButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(pickerCancelClicked:)];
+            _cancelButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(pickerCancelClicked:)];
           
-            id attributesForCancelButtonNormalState = [_cancelButtonAttributes objectForKey:kAttributesForNormalStateKey];
-            if (attributesForCancelButtonNormalState != nil && [attributesForCancelButtonNormalState isKindOfClass:[NSDictionary class]]) {
-              [cancelButton setTitleTextAttributes:(NSDictionary *)attributesForCancelButtonNormalState forState:UIControlStateNormal];
-            }
-          
-          
-            id attributesForCancelButtonnHighlightedState = [_cancelButtonAttributes objectForKey:  kAttributesForHighlightedStateKey];
-            if (attributesForCancelButtonnHighlightedState != nil && [attributesForCancelButtonnHighlightedState isKindOfClass:[NSDictionary class]]) {
-              [cancelButton setTitleTextAttributes:(NSDictionary *)attributesForCancelButtonnHighlightedState forState:UIControlStateHighlighted];
-            }
-          
-            [items addObject:cancelButton];
+            [items addObject:_cancelButton];
             
             //  Create a fake button to maintain flexibleSpace between cancelButton and titleLabel.(Otherwise the titleLabel will lean to the left）
             UIBarButtonItem *leftNilButton =[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
@@ -112,20 +103,9 @@ NSString * const kAttributesForHighlightedStateKey = @"kAttributesForHighlighted
             [items addObject:rightNilButton];
             
             //  Create a done button to show on keyboard to resign it. Adding a selector to resign it.
-            UIBarButtonItem *doneButton =[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(pickerDoneClicked:)];
-            id attributesForDoneButtonNormalState = [_doneButtonAttributes objectForKey:kAttributesForNormalStateKey];
-            if (attributesForDoneButtonNormalState != nil && [attributesForDoneButtonNormalState isKindOfClass:[NSDictionary class]]) {
-              [doneButton setTitleTextAttributes:(NSDictionary *)attributesForDoneButtonNormalState forState:UIControlStateNormal];
-            }
-          
-          
-            id attributesForDoneButtonnHighlightedState = [_doneButtonAttributes objectForKey:  kAttributesForHighlightedStateKey];
-            if (attributesForDoneButtonnHighlightedState != nil && [attributesForDoneButtonnHighlightedState isKindOfClass:[NSDictionary class]]) {
-              [doneButton setTitleTextAttributes:(NSDictionary *)attributesForDoneButtonnHighlightedState forState:UIControlStateHighlighted];
-            }
-          
-          
-            [items addObject:doneButton];
+            _doneButton =[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(pickerDoneClicked:)];
+
+            [items addObject:_doneButton];
             
             //  Adding button to toolBar.
             [_actionToolbar setItems:items];
@@ -136,7 +116,7 @@ NSString * const kAttributesForHighlightedStateKey = @"kAttributesForHighlighted
         //UIPickerView
         {
             _pickerView = [[UIPickerView alloc] initWithFrame:CGRectMake(0, CGRectGetMaxY(_actionToolbar.frame) , CGRectGetWidth(_actionToolbar.frame), 216)];
-            _pickerView.backgroundColor = [self pickerViewBackgroundColor];
+            _pickerView.backgroundColor = [UIColor whiteColor];
             [_pickerView setShowsSelectionIndicator:YES];
             [_pickerView setDelegate:self];
             [_pickerView setDataSource:self];
@@ -201,6 +181,50 @@ NSString * const kAttributesForHighlightedStateKey = @"kAttributesForHighlighted
 }
 
 /**
+ *  Set Picker View Background Color
+ *
+ *  @param pickerViewBackgroundColor Picker view custom background color
+ */
+-(void)setPickerViewBackgroundColor:(UIColor *)pickerViewBackgroundColor{
+  _pickerView.backgroundColor = pickerViewBackgroundColor;
+}
+
+/**
+ *  Set Cancel Button Title Attributes
+ *
+ *  @param cancelButtonAttributes Cancel Button Title Attributes
+ */
+-(void)setCancelButtonAttributes:(NSDictionary *)cancelButtonAttributes{
+  id attributesForCancelButtonNormalState = [cancelButtonAttributes objectForKey:kAttributesForNormalStateKey];
+  if (attributesForCancelButtonNormalState != nil && [attributesForCancelButtonNormalState isKindOfClass:[NSDictionary class]]) {
+    [_cancelButton setTitleTextAttributes:(NSDictionary *)attributesForCancelButtonNormalState forState:UIControlStateNormal];
+  }
+  
+  id attributesForCancelButtonnHighlightedState = [cancelButtonAttributes objectForKey:  kAttributesForHighlightedStateKey];
+  if (attributesForCancelButtonnHighlightedState != nil && [attributesForCancelButtonnHighlightedState isKindOfClass:[NSDictionary class]]) {
+    [_cancelButton setTitleTextAttributes:(NSDictionary *)attributesForCancelButtonnHighlightedState forState:UIControlStateHighlighted];
+  }
+}
+
+/**
+ *  Set Done Button Title Attributes
+ *
+ *  @param cancelButtonAttributes Done Button Title Attributes
+ */
+-(void)setDoneButtonAttributes:(NSDictionary *)doneButtonAttributes{
+  id attributesForDoneButtonNormalState = [doneButtonAttributes objectForKey:kAttributesForNormalStateKey];
+  if (attributesForDoneButtonNormalState != nil && [attributesForDoneButtonNormalState isKindOfClass:[NSDictionary class]]) {
+    [_doneButton setTitleTextAttributes:(NSDictionary *)attributesForDoneButtonNormalState forState:UIControlStateNormal];
+  }
+  
+  
+  id attributesForDoneButtonnHighlightedState = [doneButtonAttributes objectForKey:  kAttributesForHighlightedStateKey];
+  if (attributesForDoneButtonnHighlightedState != nil && [attributesForDoneButtonnHighlightedState isKindOfClass:[NSDictionary class]]) {
+    [_doneButton setTitleTextAttributes:(NSDictionary *)attributesForDoneButtonnHighlightedState forState:UIControlStateHighlighted];
+  }
+}
+
+/**
  *  Set Action Bar Color
  *
  *  @param barColor Custom color for toolBar
@@ -220,19 +244,6 @@ NSString * const kAttributesForHighlightedStateKey = @"kAttributesForHighlighted
     _toolbarButtonColor = toolbarButtonColor;
     
     [_actionToolbar setTintColor:toolbarButtonColor];
-}
-
-/**
- *  Get Picker View Background Color
- *
- *  @returns Picker View Background Color
- */
--(UIColor *)pickerViewBackgroundColor{
-  if (_pickerViewBackgroundColor == nil) {
-    return [UIColor whiteColor];
-  } else {
-    return _pickerViewBackgroundColor;
-  }
 }
 
 /*!

--- a/IQActionSheetPickerView/IQActionSheetPickerView.m
+++ b/IQActionSheetPickerView/IQActionSheetPickerView.m
@@ -26,6 +26,10 @@
 #import <QuartzCore/QuartzCore.h>
 #import "IQActionSheetViewController.h"
 
+NSString * const kAttributesForNormalStateKey = @"kAttributesForNormalStateKey";
+/// Identifies an attributed string of the toolbar title for highlighted state.
+NSString * const kAttributesForHighlightedStateKey = @"kAttributesForHighlightedStateKey";
+
 @interface IQActionSheetPickerView ()<UIPickerViewDataSource,UIPickerViewDelegate>
 {
     UIPickerView    *_pickerView;
@@ -72,6 +76,18 @@
             
             //  Create a cancel button to show on keyboard to resign it. Adding a selector to resign it.
             UIBarButtonItem *cancelButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(pickerCancelClicked:)];
+          
+            id attributesForCancelButtonNormalState = [_cancelButtonAttributes objectForKey:kAttributesForNormalStateKey];
+            if (attributesForCancelButtonNormalState != nil && [attributesForCancelButtonNormalState isKindOfClass:[NSDictionary class]]) {
+              [cancelButton setTitleTextAttributes:(NSDictionary *)attributesForCancelButtonNormalState forState:UIControlStateNormal];
+            }
+          
+          
+            id attributesForCancelButtonnHighlightedState = [_cancelButtonAttributes objectForKey:  kAttributesForHighlightedStateKey];
+            if (attributesForCancelButtonnHighlightedState != nil && [attributesForCancelButtonnHighlightedState isKindOfClass:[NSDictionary class]]) {
+              [cancelButton setTitleTextAttributes:(NSDictionary *)attributesForCancelButtonnHighlightedState forState:UIControlStateHighlighted];
+            }
+          
             [items addObject:cancelButton];
             
             //  Create a fake button to maintain flexibleSpace between cancelButton and titleLabel.(Otherwise the titleLabel will lean to the left）
@@ -97,6 +113,18 @@
             
             //  Create a done button to show on keyboard to resign it. Adding a selector to resign it.
             UIBarButtonItem *doneButton =[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(pickerDoneClicked:)];
+            id attributesForDoneButtonNormalState = [_doneButtonAttributes objectForKey:kAttributesForNormalStateKey];
+            if (attributesForDoneButtonNormalState != nil && [attributesForDoneButtonNormalState isKindOfClass:[NSDictionary class]]) {
+              [doneButton setTitleTextAttributes:(NSDictionary *)attributesForDoneButtonNormalState forState:UIControlStateNormal];
+            }
+          
+          
+            id attributesForDoneButtonnHighlightedState = [_doneButtonAttributes objectForKey:  kAttributesForHighlightedStateKey];
+            if (attributesForDoneButtonnHighlightedState != nil && [attributesForDoneButtonnHighlightedState isKindOfClass:[NSDictionary class]]) {
+              [doneButton setTitleTextAttributes:(NSDictionary *)attributesForDoneButtonnHighlightedState forState:UIControlStateHighlighted];
+            }
+          
+          
             [items addObject:doneButton];
             
             //  Adding button to toolBar.

--- a/IQActionSheetPickerView/IQActionSheetPickerView.m
+++ b/IQActionSheetPickerView/IQActionSheetPickerView.m
@@ -494,10 +494,13 @@ NSString * const kAttributesForHighlightedStateKey = @"kAttributesForHighlighted
 -(UIView *)pickerView:(UIPickerView *)pickerView viewForRow:(NSInteger)row forComponent:(NSInteger)component reusingView:(UIView *)view
 {
     UILabel *labelText = [[UILabel alloc] init];
-    if(self.titleFont == nil){
+    if(self.pickerComponentsColor != nil) {
+      labelText.textColor = self.pickerComponentsColor;
+    }
+    if(self.pickerComponentsFont == nil){
         labelText.font = [UIFont boldSystemFontOfSize:20.0];
     }else{
-        labelText.font = self.titleFont;
+        labelText.font = self.pickerComponentsFont;
     }
     labelText.backgroundColor = [UIColor clearColor];
     [labelText setTextAlignment:NSTextAlignmentCenter];

--- a/IQActionSheetPickerView/IQActionSheetPickerView.m
+++ b/IQActionSheetPickerView/IQActionSheetPickerView.m
@@ -108,7 +108,7 @@
         //UIPickerView
         {
             _pickerView = [[UIPickerView alloc] initWithFrame:CGRectMake(0, CGRectGetMaxY(_actionToolbar.frame) , CGRectGetWidth(_actionToolbar.frame), 216)];
-            _pickerView.backgroundColor = [UIColor whiteColor];
+            _pickerView.backgroundColor = [self pickerViewBackgroundColor];
             [_pickerView setShowsSelectionIndicator:YES];
             [_pickerView setDelegate:self];
             [_pickerView setDataSource:self];
@@ -192,6 +192,19 @@
     _toolbarButtonColor = toolbarButtonColor;
     
     [_actionToolbar setTintColor:toolbarButtonColor];
+}
+
+/**
+ *  Get Picker View Background Color
+ *
+ *  @returns Picker View Background Color
+ */
+-(UIColor *)pickerViewBackgroundColor{
+  if (_pickerViewBackgroundColor == nil) {
+    return [UIColor whiteColor];
+  } else {
+    return _pickerViewBackgroundColor;
+  }
 }
 
 /*!

--- a/IQActionSheetPickerView/IQActionSheetViewController.m
+++ b/IQActionSheetPickerView/IQActionSheetViewController.m
@@ -35,7 +35,16 @@
 {
     self.view = [[UIView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     self.view.backgroundColor = [UIColor clearColor];
+    UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapFrom:)];
+    [self.view addGestureRecognizer:tapGestureRecognizer];
 }
+
+- (void) handleTapFrom: (UITapGestureRecognizer *)recognizer
+{
+  //Code to handle the gesture
+  [self dismissWithCompletion:nil];
+}
+
 
 -(void)showPickerView:(IQActionSheetPickerView*)pickerView completion:(void (^)(void))completion
 {

--- a/IQActionSheetPickerView/IQActionSheetViewController.m
+++ b/IQActionSheetPickerView/IQActionSheetViewController.m
@@ -25,11 +25,11 @@
 #import "IQActionSheetViewController.h"
 #import "IQActionSheetPickerView.h"
 
-@interface IQActionSheetViewController ()<UIApplicationDelegate>
+@interface IQActionSheetViewController ()<UIApplicationDelegate, UIGestureRecognizerDelegate>
 
 @end
 
-@implementation IQActionSheetViewController
+@implementation IQActionSheetViewController 
 
 -(void)loadView
 {
@@ -37,12 +37,23 @@
     self.view.backgroundColor = [UIColor clearColor];
     UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapFrom:)];
     [self.view addGestureRecognizer:tapGestureRecognizer];
+    tapGestureRecognizer.delegate = self;
 }
 
 - (void) handleTapFrom: (UITapGestureRecognizer *)recognizer
 {
   //Code to handle the gesture
   [self dismissWithCompletion:nil];
+}
+
+// MAKR: <UIGestureRecognizerDelegate>
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+       shouldReceiveTouch:(UITouch *)touch
+{
+    if (CGRectContainsPoint([self.pickerView bounds], [touch locationInView:self.pickerView]))
+      return NO;
+  
+    return YES;
 }
 
 


### PR DESCRIPTION
Here is a list of new customization options:

- Customize picker view background color.  Usage:

`[[IQActionSheetPickerView appearance]setPickerViewBackgroundColor: [UIColor orangeColor]];`

- Customize picker components font and color: Usage: 

` [[IQActionSheetPickerView appearance]setPickerComponentsColor: [UIColor grayColor]];`

` [[IQActionSheetPickerView appearance]setPickerComponentsFont: [UIFont systemFontOfSize:17.0]];`

- Customize cancel and done button title attributes. Usage:

`NSDictionary *attributesForNormalState = @{NSForegroundColorAttributeName: [UIColor redColor], NSFontAttributeName: [UIFont systemFontOfSize: 18.0] };`

`[[IQActionSheetPickerView appearance]setCancelButtonAttributes: @{ kAttributesForNormalStateKey: attributesForNormalState}];`

And as a bonus: the picker can be dismissed now on a background (dimmed view) tap.

